### PR TITLE
Fixes npm instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ specifically contains some inuitcss default variables and mixins, as well as
     @import "bower_components/inuit-page/base.page";
 
 If you use npm instead of bower, replace all occurrances of `bower_components`
-with `node_modules`.
+with `node_modules/inuit-starter-kit/node_modules`.


### PR DESCRIPTION
Since starter kit is a placeholder module, all it has upon `npm install` is `node_modules` directory with dependencies and simply replacing `bower_components` with `node_modules` won't work.
